### PR TITLE
Fix flash URL and adapt to changes in the tag plugin

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -68,7 +68,7 @@ class syntax_plugin_cumulus extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= $this->getLang('filenotfound');
             return true;
         }
-        $movie = '/lib/plugins/'.$movie.'?r='.rand(0,9999999);
+        $movie = DOKU_BASE.'lib/plugins/'.$movie.'?r='.rand(0,9999999);
         
         // write flash tag
         $params = array(

--- a/syntax.php
+++ b/syntax.php
@@ -253,20 +253,7 @@ class syntax_plugin_cumulus extends DokuWiki_Syntax_Plugin {
      * (from DokuWiki Cloud plugin by Gina Häußge, Michael Klier, Esther Brunner)
      */
     function _getTagCloud($num, &$min, &$max, &$tag) {
-        $cloud = array();
-        if(!is_array($tag->topic_idx)) return;
-        foreach ($tag->topic_idx as $key => $value) {
-            if (!is_array($value) || empty($value) || (!trim($value[0]))) {
-                continue;
-            } else {
-                $pages = array();
-                foreach($value as $page) {
-                    if(auth_quickaclcheck($page) < AUTH_READ) continue;
-                    array_push($pages, $page);
-                }
-                if(!empty($pages)) $cloud[$key] = count($pages);
-            }
-        }
+        $cloud = $tag->tagOccurrences(NULL, NULL, true);
         return $this->_sortCloud($cloud, $num, $min, $max);
     }
 


### PR DESCRIPTION
This pull request actually contains two separate changes:
- I fixed the flash URL for wikis not installed in the root directory
- I adapted the code of the cumulus plugin to work with the changed tag plugin
